### PR TITLE
Migrate core modules to KMP

### DIFF
--- a/client-core-mock/build.gradle.kts
+++ b/client-core-mock/build.gradle.kts
@@ -30,11 +30,32 @@
  */
 
 plugins {
+    alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.nordic.kotlin)
-    alias(libs.plugins.nordic.publish.jvm)
+    alias(libs.plugins.nordic.publish.kmp)
 }
 
 group = "no.nordicsemi.kotlin.ble"
+
+kotlin {
+    jvm()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosArm64()
+
+    sourceSets {
+        commonMain {
+            kotlin.srcDir("src/main/java")
+            dependencies {
+                api(project(":core-mock"))
+                api(project(":client-core"))
+                // Required for support @Range inside KMP
+                api(libs.annotations)
+            }
+        }
+    }
+}
 
 nordicPublishing {
     POM_ARTIFACT_ID = "client-core-mock"
@@ -47,9 +68,6 @@ nordicPublishing {
 }
 
 dependencies {
-    api(project(":core-mock"))
-    api(project(":client-core"))
-
     // Adds @hide annotation to exclude internal classes from the documentation.
     dokkaPlugin(libs.dokka.android.gradlePlugin)
 }

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpec.kt
@@ -35,6 +35,7 @@ package no.nordicsemi.kotlin.ble.client.mock
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpecEventHandler.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpecEventHandler.kt
@@ -101,7 +101,7 @@ sealed class ReadResponse {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            if (javaClass != other?.javaClass) return false
+            if (other == null || this::class != other::class) return false
 
             other as Success
 
@@ -165,7 +165,7 @@ sealed class PrepareWriteResponse {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            if (javaClass != other?.javaClass) return false
+            if (other == null || this::class != other::class) return false
 
             other as Success
 

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockBluetoothLeAdvertiser.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockBluetoothLeAdvertiser.kt
@@ -31,6 +31,7 @@
 
 package no.nordicsemi.kotlin.ble.client.mock.internal
 
+import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -106,7 +107,7 @@ class MockBluetoothLeAdvertiser<ID: Any>(
                                         txPowerLevel = txPowerLevel,
                                         primaryPhy = primaryPhy,
                                         secondaryPhy = secondaryPhy,
-                                        timestamp = System.currentTimeMillis() // TODO different time
+                                        timestamp = Clock.System.now().toEpochMilliseconds() // TODO different time
                                     )
                                     _advertisingEvents.emit(scanResult)
                                 }

--- a/client-core/build.gradle.kts
+++ b/client-core/build.gradle.kts
@@ -30,11 +30,32 @@
  */
 
 plugins {
+    alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.nordic.kotlin)
-    alias(libs.plugins.nordic.publish.jvm)
+    alias(libs.plugins.nordic.publish.kmp)
 }
 
 group = "no.nordicsemi.kotlin.ble"
+
+kotlin {
+    jvm()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosArm64()
+
+    sourceSets {
+        commonMain {
+            kotlin.srcDir("src/main/java")
+            dependencies {
+                api(project(":core"))
+                api(libs.kotlinx.datetime)
+                // Required for support @Range inside KMP
+                api(libs.annotations)
+            }
+        }
+    }
+}
 
 nordicPublishing {
     POM_ARTIFACT_ID = "client-core"
@@ -47,10 +68,6 @@ nordicPublishing {
 }
 
 dependencies {
-    api(project(":core"))
-
-    api(libs.kotlinx.datetime)
-
     // Adds @hide annotation to exclude internal classes from the documentation.
     dokkaPlugin(libs.dokka.android.gradlePlugin)
 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/Peripheral.kt
@@ -33,6 +33,7 @@
 
 package no.nordicsemi.kotlin.ble.client
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -72,7 +73,6 @@ import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.internal.withCallSite
 import no.nordicsemi.kotlin.ble.core.log.Layer
 import no.nordicsemi.kotlin.log.Log
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.uuid.Uuid
@@ -289,7 +289,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
      *        false to keep collecting events.
      */
     protected fun startCollectingGattEvents(closeWhenDisconnected: Boolean = true) {
-        assert(gattEventCollector == null) {
+        check(gattEventCollector == null) {
             "Previous GATT event collector wasn't nullified before creating a new one"
         }
 
@@ -1094,7 +1094,7 @@ abstract class Peripheral<ID: Any, EX: Peripheral.Executor<ID>>(
                         // When the services get invalidated, of the device gets disconnected,
                         // cancel the user job (if running).
                         val cause = if (isConnected) InvalidAttributeException() else PeripheralNotConnectedException()
-                        userJob?.cancel(CancellationException(cause))
+                        userJob?.cancel(CancellationException(cause.toString(), cause))
                         // Do not cancel the user scope here. The device may get reconnected.
                         // User scope is continuing observing the services.
                     }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -52,6 +52,7 @@ import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
+import no.nordicsemi.kotlin.ble.core.exception.SecurityException
 import no.nordicsemi.kotlin.ble.core.internal.CallSiteException
 import no.nordicsemi.kotlin.ble.core.internal.withCallSite
 import no.nordicsemi.kotlin.ble.core.util.MergeResult

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteDescriptor.kt
@@ -46,6 +46,7 @@ import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.ValueDoesNotMatchException
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
+import no.nordicsemi.kotlin.ble.core.exception.SecurityException
 import no.nordicsemi.kotlin.ble.core.internal.withCallSite
 
 abstract class BaseRemoteDescriptor(

--- a/core-mock/build.gradle.kts
+++ b/core-mock/build.gradle.kts
@@ -30,11 +30,31 @@
  */
 
 plugins {
+    alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.nordic.kotlin)
-    alias(libs.plugins.nordic.publish.jvm)
+    alias(libs.plugins.nordic.publish.kmp)
 }
 
 group = "no.nordicsemi.kotlin.ble"
+
+kotlin {
+    jvm()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosArm64()
+
+    sourceSets {
+        commonMain {
+            kotlin.srcDir("src/main/java")
+            dependencies {
+                api(project(":core"))
+                // Required for support @Range inside KMP
+                api(libs.annotations)
+            }
+        }
+    }
+}
 
 nordicPublishing {
     POM_ARTIFACT_ID = "core-mock"
@@ -44,10 +64,6 @@ nordicPublishing {
     POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
     POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
     POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-}
-
-dependencies {
-    api(project(":core"))
 }
 
 dokka {

--- a/core-mock/src/main/java/no/nordicsemi/kotlin/ble/core/mock/AdvertisingDataDefinition.kt
+++ b/core-mock/src/main/java/no/nordicsemi/kotlin/ble/core/mock/AdvertisingDataDefinition.kt
@@ -119,10 +119,10 @@ class AdvertisingDataDefinition(
                     }
                 }
                 AdvertisingDataType.COMPLETE_LOCAL_NAME -> {
-                    completeName = String(raw, i, length)
+                    completeName = raw.decodeToString(i, i + length)
                 }
                 AdvertisingDataType.SHORTENED_LOCAL_NAME -> {
-                    shortenedName = String(raw, i, length)
+                    shortenedName = raw.decodeToString(i, i + length)
                 }
                 AdvertisingDataType.SERVICE_DATA_16_BIT -> {
                     val uuid = Uuid.fromBytes(raw, i, 2)
@@ -240,8 +240,8 @@ class AdvertisingDataDefinition(
     ) : this(
         byteArrayOf(
             *encode(AdvertisingDataType.FLAGS, flags?.value),
-            *encode(AdvertisingDataType.COMPLETE_LOCAL_NAME, completeLocalName?.toByteArray()),
-            *encode(AdvertisingDataType.SHORTENED_LOCAL_NAME, shortenedLocalName?.toByteArray()),
+            *encode(AdvertisingDataType.COMPLETE_LOCAL_NAME, completeLocalName?.encodeToByteArray()),
+            *encode(AdvertisingDataType.SHORTENED_LOCAL_NAME, shortenedLocalName?.encodeToByteArray()),
             *encode(AdvertisingDataType.TX_POWER_LEVEL, txPowerLevel?.toByte()),
             *encodeServiceUuids(serviceUuids),
             *encodeServiceSolicitationUuids(serviceSolicitationUuids),

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -39,6 +39,10 @@ group = "no.nordicsemi.kotlin.ble"
 
 kotlin {
     jvm()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosArm64()
 
     sourceSets {
         commonMain {
@@ -51,6 +55,9 @@ kotlin {
         }
         jvmMain {
             kotlin.srcDir("src/jvmMain/kotlin")
+        }
+        appleMain {
+            kotlin.srcDir("src/appleMain/kotlin")
         }
     }
 

--- a/core/src/appleMain/kotlin/no/nordicsemi/kotlin/ble/core/Closable.kt
+++ b/core/src/appleMain/kotlin/no/nordicsemi/kotlin/ble/core/Closable.kt
@@ -29,43 +29,11 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.nordic.kotlin)
-    alias(libs.plugins.nordic.publish.kmp)
-}
+package no.nordicsemi.kotlin.ble.core
 
-group = "no.nordicsemi.kotlin.ble"
-
-kotlin {
-    jvm()
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosArm64()
-
-    sourceSets {
-        commonMain {
-            kotlin.srcDir("src/main/java")
-            dependencies {
-                api(project(":core"))
-            }
-        }
-    }
-}
-
-nordicPublishing {
-    POM_ARTIFACT_ID = "advertiser-core"
-    POM_NAME = "Core Advertiser Module"
-    POM_DESCRIPTION = "A part of Kotlin BLE Library providing core, platform-independent functionality for Bluetooth LE advertising."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-    POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-}
-
-dokka {
-    dokkaSourceSets.configureEach {
-        includes.from("Module.md")
-    }
+/**
+ * Apple's alias for JVM's java.io.Closeable
+ */
+actual interface Closable {
+    actual fun close()
 }

--- a/core/src/appleMain/kotlin/no/nordicsemi/kotlin/ble/core/exception/SecurityException.kt
+++ b/core/src/appleMain/kotlin/no/nordicsemi/kotlin/ble/core/exception/SecurityException.kt
@@ -29,43 +29,8 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.nordic.kotlin)
-    alias(libs.plugins.nordic.publish.kmp)
-}
+package no.nordicsemi.kotlin.ble.core.exception
 
-group = "no.nordicsemi.kotlin.ble"
-
-kotlin {
-    jvm()
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosArm64()
-
-    sourceSets {
-        commonMain {
-            kotlin.srcDir("src/main/java")
-            dependencies {
-                api(project(":core"))
-            }
-        }
-    }
-}
-
-nordicPublishing {
-    POM_ARTIFACT_ID = "advertiser-core"
-    POM_NAME = "Core Advertiser Module"
-    POM_DESCRIPTION = "A part of Kotlin BLE Library providing core, platform-independent functionality for Bluetooth LE advertising."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-    POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-}
-
-dokka {
-    dokkaSourceSets.configureEach {
-        includes.from("Module.md")
-    }
-}
+actual class SecurityException actual constructor(
+    message: String
+) : RuntimeException(message)

--- a/core/src/jvmMain/kotlin/no/nordicsemi/kotlin/ble/core/exception/SecurityException.kt
+++ b/core/src/jvmMain/kotlin/no/nordicsemi/kotlin/ble/core/exception/SecurityException.kt
@@ -29,43 +29,9 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.nordic.kotlin)
-    alias(libs.plugins.nordic.publish.kmp)
-}
+package no.nordicsemi.kotlin.ble.core.exception
 
-group = "no.nordicsemi.kotlin.ble"
-
-kotlin {
-    jvm()
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosArm64()
-
-    sourceSets {
-        commonMain {
-            kotlin.srcDir("src/main/java")
-            dependencies {
-                api(project(":core"))
-            }
-        }
-    }
-}
-
-nordicPublishing {
-    POM_ARTIFACT_ID = "advertiser-core"
-    POM_NAME = "Core Advertiser Module"
-    POM_DESCRIPTION = "A part of Kotlin BLE Library providing core, platform-independent functionality for Bluetooth LE advertising."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-    POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-}
-
-dokka {
-    dokkaSourceSets.configureEach {
-        includes.from("Module.md")
-    }
-}
+/**
+ * Alias for JVM's java.lang.SecurityException but for KMP
+ */
+actual typealias SecurityException = java.lang.SecurityException

--- a/core/src/main/java/no/nordicsemi/kotlin/ble/core/exception/SecurityException.kt
+++ b/core/src/main/java/no/nordicsemi/kotlin/ble/core/exception/SecurityException.kt
@@ -29,43 +29,9 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.nordic.kotlin)
-    alias(libs.plugins.nordic.publish.kmp)
-}
+package no.nordicsemi.kotlin.ble.core.exception
 
-group = "no.nordicsemi.kotlin.ble"
-
-kotlin {
-    jvm()
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
-    macosArm64()
-
-    sourceSets {
-        commonMain {
-            kotlin.srcDir("src/main/java")
-            dependencies {
-                api(project(":core"))
-            }
-        }
-    }
-}
-
-nordicPublishing {
-    POM_ARTIFACT_ID = "advertiser-core"
-    POM_NAME = "Core Advertiser Module"
-    POM_DESCRIPTION = "A part of Kotlin BLE Library providing core, platform-independent functionality for Bluetooth LE advertising."
-    POM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_URL = "https://github.com/nordicsemi/Kotlin-BLE-Library/"
-    POM_SCM_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-    POM_SCM_DEV_CONNECTION = "scm:git@github.com:nordicsemi/Kotlin-BLE-Library.git"
-}
-
-dokka {
-    dokkaSourceSets.configureEach {
-        includes.from("Module.md")
-    }
-}
+/**
+ * Alias for JVM's `java.lang.SecurityException`
+ */
+expect class SecurityException(message: String) : RuntimeException


### PR DESCRIPTION
Migrated modules to KMP
- Migrated `advertiser-core`
- Migrated `client-core-mock`
- Migrated `client-core`
- Migrated `core-mock`
- Migrated `core`