### PR TITLE
Add explicit notification and indication subscription modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,17 @@ remoteService.characteristics.forEach { remoteCharacteristic ->
 
 #### Subscribing to value changes
 
+When a characteristic supports both notifications and indications, the default behavior prefers
+indications. Select a mode explicitly when the peripheral requires one:
+
+```kotlin
+remoteCharacteristic.subscribe(SubscriptionMode.NOTIFICATION)
+    .onEach { newValue ->
+        Timber.i("Value changed: 0x${newValue.toHexString()}")
+    }
+    .launchIn(scope)
+```
+
 ```kotlin
 remoteService.characteristics.forEach { remoteCharacteristic ->
     try {

--- a/client-core-mock/build.gradle.kts
+++ b/client-core-mock/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
     api(project(":core-mock"))
     api(project(":client-core"))
 
+    testImplementation(libs.kotlin.test)
+
     // Adds @hide annotation to exclude internal classes from the documentation.
     dokkaPlugin(libs.dokka.android.gradlePlugin)
 }

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpecEventHandler.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/PeripheralSpecEventHandler.kt
@@ -492,6 +492,8 @@ interface PeripheralSpecEventHandler {
      * @param value The value written to the characteristic descriptor.
      * @return The response of the write operation. This emulates a response received from the peripheral,
      * and it will be delayed to the client by one connection interval.
+     * Client Characteristic Configuration Descriptor writes are also delivered here, allowing
+     * a mock peripheral to accept or reject notification and indication modes.
      * @throws OperationFailedException in case of a client error (reported without a delay).
      */
     fun onWriteRequest(descriptor: MockRemoteDescriptor, value: ByteArray): WriteResponse {

--- a/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockRemoteDescriptor.kt
+++ b/client-core-mock/src/main/java/no/nordicsemi/kotlin/ble/client/mock/internal/MockRemoteDescriptor.kt
@@ -65,6 +65,12 @@ class MockRemoteDescriptor(
 ): BaseRemoteDescriptor(parent, events) {
     override val uuid: Uuid = descriptor.uuid
     override val instanceId: Int = descriptor.instanceId
+    private val cccdState = (descriptor as? CCCD)?.let {
+        CccdState(
+            enabled = it.enabled,
+            properties = characteristic.properties,
+        )
+    }
 
     override suspend fun FlowCollector<GattEvent>.executeRead() {
         val eventHandler = checkNotNull(peripheralSpec.eventHandler)
@@ -108,7 +114,7 @@ class MockRemoteDescriptor(
         }
 
         val result = when (descriptor) {
-            is CCCD -> ReadResponse.Success(descriptor.value)
+            is CCCD -> ReadResponse.Success(checkNotNull(cccdState).value)
             is CUD -> ReadResponse.Success(descriptor.value)
             is CEPD -> ReadResponse.Success(descriptor.value)
             else -> eventHandler.onReadRequest(this@MockRemoteDescriptor)
@@ -250,13 +256,10 @@ class MockRemoteDescriptor(
             false -> {
                 val result = when (descriptor) {
                     is CCCD -> {
-                        // Values 0x01-00 and 0x02-00 are used to enable notifications and indications, respectively.
-                        // Value 0x00-00 is used to disable both.
-                        // Any other value is RFU and ignored.
-                        if (data.size == 2 && data[0] >= 0 && data[0] <= 1 && data[1] == 0.toByte()) {
-                            descriptor.enabled = data[1] > 0
+                        val response = eventHandler.onWriteRequest(this@MockRemoteDescriptor, truncatedData)
+                        checkNotNull(cccdState).write(truncatedData, response).also {
+                            descriptor.enabled = cccdState.isEnabled
                         }
-                        WriteResponse.Success
                     }
                     else -> eventHandler.onWriteRequest(this@MockRemoteDescriptor, truncatedData)
                 }
@@ -291,14 +294,6 @@ class MockRemoteDescriptor(
 
     override fun OperationEvent.matches(): Boolean = this.subject == this@MockRemoteDescriptor
 
-    /** The value of the CCCD in bytes. */
-    val CCCD.value: ByteArray
-        get() = when {
-            enabled && CharacteristicProperty.NOTIFY in characteristic.properties -> ENABLE_NOTIFICATIONS_VALUE
-            enabled && CharacteristicProperty.INDICATE in characteristic.properties -> ENABLE_INDICATIONS_VALUE
-            else -> DISABLE_NOTIFICATIONS_VALUE
-        }
-
     /** The value of the CUD in bytes. */
     val CUD.value: ByteArray
         get() = this.description.encodeToByteArray()
@@ -312,4 +307,42 @@ class MockRemoteDescriptor(
             // Other bits are reserved and set to 0.
             return byteArrayOf(flags.toByte(), 0.toByte())
         }
+}
+
+internal class CccdState(
+    enabled: Boolean,
+    private val properties: Set<CharacteristicProperty>,
+) {
+    var value: ByteArray = when {
+        !enabled -> BaseRemoteDescriptor.DISABLE_NOTIFICATIONS_VALUE
+        CharacteristicProperty.NOTIFY in properties -> BaseRemoteDescriptor.ENABLE_NOTIFICATIONS_VALUE
+        CharacteristicProperty.INDICATE in properties -> BaseRemoteDescriptor.ENABLE_INDICATIONS_VALUE
+        else -> BaseRemoteDescriptor.DISABLE_NOTIFICATIONS_VALUE
+    }
+        private set
+
+    val isEnabled: Boolean
+        get() = !value.contentEquals(BaseRemoteDescriptor.DISABLE_NOTIFICATIONS_VALUE)
+
+    fun write(
+        newValue: ByteArray,
+        response: WriteResponse = WriteResponse.Success,
+    ): WriteResponse = when {
+        response is WriteResponse.Failure -> response
+        newValue.contentEquals(BaseRemoteDescriptor.DISABLE_NOTIFICATIONS_VALUE) -> {
+            value = BaseRemoteDescriptor.DISABLE_NOTIFICATIONS_VALUE
+            WriteResponse.Success
+        }
+        newValue.contentEquals(BaseRemoteDescriptor.ENABLE_NOTIFICATIONS_VALUE) &&
+                CharacteristicProperty.NOTIFY in properties -> {
+            value = BaseRemoteDescriptor.ENABLE_NOTIFICATIONS_VALUE
+            WriteResponse.Success
+        }
+        newValue.contentEquals(BaseRemoteDescriptor.ENABLE_INDICATIONS_VALUE) &&
+                CharacteristicProperty.INDICATE in properties -> {
+            value = BaseRemoteDescriptor.ENABLE_INDICATIONS_VALUE
+            WriteResponse.Success
+        }
+        else -> WriteResponse.Failure(OperationStatus.ValueNotAllowed)
+    }
 }

--- a/client-core-mock/src/test/java/no/nordicsemi/kotlin/ble/client/mock/internal/CccdStateTest.kt
+++ b/client-core-mock/src/test/java/no/nordicsemi/kotlin/ble/client/mock/internal/CccdStateTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.client.mock.internal
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import no.nordicsemi.kotlin.ble.client.mock.WriteResponse
+import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
+import no.nordicsemi.kotlin.ble.core.OperationStatus
+
+class CccdStateTest {
+    @Test
+    fun `initial dual-property state retains notification-first mock behavior`() {
+        val state = CccdState(enabled = true, properties = dualProperties)
+
+        assertContentEquals(notificationValue, state.value)
+        assertTrue(state.isEnabled)
+    }
+
+    @Test
+    fun `notification and indication values are stored exactly`() {
+        val state = CccdState(enabled = false, properties = dualProperties)
+
+        assertEquals(WriteResponse.Success, state.write(indicationValue))
+        assertContentEquals(indicationValue, state.value)
+        assertEquals(WriteResponse.Success, state.write(notificationValue))
+        assertContentEquals(notificationValue, state.value)
+    }
+
+    @Test
+    fun `unsupported mode fails without changing the current value`() {
+        val state = CccdState(
+            enabled = false,
+            properties = setOf(CharacteristicProperty.NOTIFY),
+        )
+
+        assertEquals(
+            WriteResponse.Failure(OperationStatus.ValueNotAllowed),
+            state.write(indicationValue),
+        )
+        assertContentEquals(disabledValue, state.value)
+        assertFalse(state.isEnabled)
+    }
+
+    @Test
+    fun `peripheral rejection is preserved without changing the current value`() {
+        val state = CccdState(enabled = false, properties = dualProperties)
+        val rejection = WriteResponse.Failure(
+            OperationStatus.ClientCharacteristicConfigurationDescriptorImproperlyConfigured,
+        )
+
+        assertEquals(rejection, state.write(indicationValue, rejection))
+        assertContentEquals(disabledValue, state.value)
+        assertFalse(state.isEnabled)
+    }
+
+    @Test
+    fun `disable value clears an active subscription`() {
+        val state = CccdState(enabled = true, properties = dualProperties)
+
+        assertEquals(WriteResponse.Success, state.write(disabledValue))
+
+        assertContentEquals(disabledValue, state.value)
+        assertFalse(state.isEnabled)
+    }
+
+    private companion object {
+        val dualProperties = setOf(
+            CharacteristicProperty.NOTIFY,
+            CharacteristicProperty.INDICATE,
+        )
+        val disabledValue = byteArrayOf(0x00, 0x00)
+        val notificationValue = byteArrayOf(0x01, 0x00)
+        val indicationValue = byteArrayOf(0x02, 0x00)
+    }
+}

--- a/client-core/build.gradle.kts
+++ b/client-core/build.gradle.kts
@@ -51,6 +51,8 @@ dependencies {
 
     api(libs.kotlinx.datetime)
 
+    testImplementation(libs.kotlin.test)
+
     // Adds @hide annotation to exclude internal classes from the documentation.
     dokkaPlugin(libs.dokka.android.gradlePlugin)
 }

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/RemoteCharacteristic.kt
@@ -70,6 +70,8 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      *
      * This method writes to the Client Characteristic Configuration Descriptor (CCCD)
      * belonging to this characteristic to enable or disable notifications or indications.
+     * If both modes are supported, indications are preferred. Use the overload accepting
+     * [SubscriptionMode] to select a mode explicitly.
      *
      * Note: [subscribe] or [waitForValueChange] enable notifications automatically.
      *
@@ -176,6 +178,8 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * If not already enabled, this method enables notifications or indications automatically
      * on subscription, that is when a terminal operator (`collect`, `first`, etc.) is invoked on
      * the returned flow.
+     * If both modes are supported, indications are preferred. Use the overload accepting
+     * [SubscriptionMode] to select a mode explicitly.
      *
      * [onSubscription] callback is invoked when the notifications or indications have been
      * enabled successfully.
@@ -238,6 +242,8 @@ interface RemoteCharacteristic: Characteristic<RemoteDescriptor> {
      * This method suspends until the value of the characteristic changes.
      * If the notifications or indications are not enabled, this method will enable them
      * automatically after subscribing for value changes.
+     * If both modes are supported, indications are preferred. Use the overload accepting
+     * [SubscriptionMode] to select a mode explicitly.
      *
      * ```kotlin
      * val newValue = remoteCharacteristic.waitForValueChange(

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/SubscriptionMode.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/SubscriptionMode.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.client
+
+import kotlinx.coroutines.flow.Flow
+import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
+import no.nordicsemi.kotlin.ble.client.internal.BaseRemoteCharacteristic
+import no.nordicsemi.kotlin.ble.core.OperationStatus
+import no.nordicsemi.kotlin.ble.core.util.MergeResult
+
+/**
+ * Selects how a characteristic subscribes for value changes.
+ */
+enum class SubscriptionMode {
+    /**
+     * Selects the subscription mode from the characteristic properties.
+     *
+     * Indications have priority over notifications when both are supported, preserving the
+     * existing behavior.
+     */
+    AUTOMATIC,
+
+    /** Requires and enables notifications. */
+    NOTIFICATION,
+
+    /** Requires and enables indications. */
+    INDICATION,
+}
+
+/**
+ * Enables or disables value changes using an explicit [mode].
+ *
+ * Disabling value changes ignores [mode]. Implementations not based on
+ * [BaseRemoteCharacteristic] support only [SubscriptionMode.AUTOMATIC] when enabling.
+ */
+suspend fun RemoteCharacteristic.setNotifying(
+    enabled: Boolean,
+    mode: SubscriptionMode,
+) {
+    when (this) {
+        is BaseRemoteCharacteristic -> setNotifying(enabled, mode)
+        else -> {
+            if (enabled && mode != SubscriptionMode.AUTOMATIC) unsupportedSubscriptionMode()
+            setNotifying(enabled)
+        }
+    }
+}
+
+/**
+ * Subscribes for value changes using an explicit [mode].
+ */
+fun RemoteCharacteristic.subscribe(
+    mode: SubscriptionMode,
+    onSubscription: suspend RemoteCharacteristic.() -> Unit = {},
+): Flow<ByteArray> = when (this) {
+    is BaseRemoteCharacteristic -> subscribe(mode, onSubscription)
+    else -> {
+        if (mode != SubscriptionMode.AUTOMATIC) unsupportedSubscriptionMode()
+        subscribe(onSubscription)
+    }
+}
+
+/**
+ * Waits for a value change using an explicit [mode].
+ */
+suspend fun RemoteCharacteristic.waitForValueChange(
+    mode: SubscriptionMode,
+    rawDataFilter: ((ByteArray) -> Boolean) = { true },
+    merge: suspend (accumulator: ByteArray, received: ByteArray, index: Int) -> MergeResult =
+        { _, received, _ -> MergeResult.Completed(received) },
+    filter: ((ByteArray) -> Boolean) = { true },
+    trigger: suspend RemoteCharacteristic.() -> Unit = {},
+): ByteArray = when (this) {
+    is BaseRemoteCharacteristic -> waitForValueChange(mode, rawDataFilter, merge, filter, trigger)
+    else -> {
+        if (mode != SubscriptionMode.AUTOMATIC) unsupportedSubscriptionMode()
+        waitForValueChange(rawDataFilter, merge, filter, trigger)
+    }
+}
+
+private fun unsupportedSubscriptionMode(): Nothing =
+    throw OperationFailedException(OperationStatus.SubscribeNotPermitted)

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/BaseRemoteCharacteristic.kt
@@ -45,10 +45,10 @@ import no.nordicsemi.kotlin.ble.client.AnyRemoteService
 import no.nordicsemi.kotlin.ble.client.GattEvent
 import no.nordicsemi.kotlin.ble.client.RemoteCharacteristic
 import no.nordicsemi.kotlin.ble.client.RemoteDescriptor
+import no.nordicsemi.kotlin.ble.client.SubscriptionMode
 import no.nordicsemi.kotlin.ble.client.exception.InvalidAttributeException
 import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
 import no.nordicsemi.kotlin.ble.client.exception.ValueDoesNotMatchException
-import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
 import no.nordicsemi.kotlin.ble.core.OperationStatus
 import no.nordicsemi.kotlin.ble.core.WriteType
 import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
@@ -119,53 +119,42 @@ abstract class BaseRemoteCharacteristic(
     abstract fun OperationEvent.matches(): Boolean
 
     /** A flag indicating whether notifications or indications are enabled.  */
-    private var _isNotifying: Boolean = false
+    private val subscriptionController = SubscriptionController()
     final override val isNotifying: Boolean
-        get() = owner != null && _isNotifying
+        get() = owner != null && subscriptionController.isEnabled
 
-    final override suspend fun setNotifying(enabled: Boolean) = withCallSite("setNotifying") {
-        // Check whether the characteristic wasn't invalidated.
-        val owner = requireNotNull(owner) {
-            throw InvalidAttributeException()
+    final override suspend fun setNotifying(enabled: Boolean) =
+        setNotifying(enabled, SubscriptionMode.AUTOMATIC)
+
+    internal suspend fun setNotifying(enabled: Boolean, mode: SubscriptionMode) =
+        withCallSite("setNotifying") {
+            // Check whether the characteristic wasn't invalidated.
+            val owner = requireNotNull(owner) {
+                throw InvalidAttributeException()
+            }
+
+            // Check whether accessing the attribute is permitted.
+            require(owner.executor.environment.isSystem || !isRestricted()) {
+                throw SecurityException("Subscribing to value changes from characteristic $uuid is not permitted")
+            }
+
+            // Verify that the characteristic can be subscribed to.
+            require(isSubscribable()) {
+                throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
+            }
+
+            // Check if the CCCD descriptor exists.
+            val cccd = descriptors.cccd()
+                ?: throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
+
+            subscriptionController.setNotifying(
+                enabled = enabled,
+                requestedMode = mode,
+                properties = properties,
+                setLocalRegistration = ::setCharacteristicNotification,
+                writeCccd = cccd::write,
+            )
         }
-
-        // Check whether accessing the attribute is permitted.
-        require(owner.executor.environment.isSystem || !isRestricted()) {
-            throw SecurityException("Subscribing to value changes from characteristic $uuid is not permitted")
-        }
-
-        // If the current state of notifications is the same as the requested state, return.
-        if (enabled == isNotifying)
-            return@withCallSite
-
-        // Verify that the characteristic can be subscribed to.
-        require(isSubscribable()) {
-            throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
-        }
-
-        // Check if the CCCD descriptor exists.
-        val cccd = descriptors.cccd()
-            ?: throw OperationFailedException(OperationStatus.SubscribeNotPermitted)
-
-        // Enable handling of notifications or indications locally.
-        try {
-            setCharacteristicNotification(enabled)
-        } catch (e: OperationFailedException) {
-            throw e
-        } catch (e: Exception) {
-            throw BluetoothException(e)
-        }
-
-        // Enable notifications or indications by writing to the CCCD descriptor.
-        val value = when {
-            // Note: Indicate has priority over Notify, if both are supported.
-            enabled && CharacteristicProperty.INDICATE in properties -> BaseRemoteDescriptor.ENABLE_INDICATIONS_VALUE
-            enabled -> BaseRemoteDescriptor.ENABLE_NOTIFICATIONS_VALUE
-            else -> BaseRemoteDescriptor.DISABLE_NOTIFICATIONS_VALUE
-        }
-        cccd.write(value)
-        _isNotifying = enabled
-    }
 
     final override suspend fun read(): ByteArray = withCallSite("read") {
         // Check whether the characteristic wasn't invalidated.
@@ -288,8 +277,22 @@ abstract class BaseRemoteCharacteristic(
         merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
         filter: (ByteArray) -> Boolean,
         trigger: suspend RemoteCharacteristic.() -> Unit,
+    ): ByteArray = waitForValueChange(
+        SubscriptionMode.AUTOMATIC,
+        rawDataFilter,
+        merge,
+        filter,
+        trigger,
+    )
+
+    internal suspend fun waitForValueChange(
+        mode: SubscriptionMode,
+        rawDataFilter: (ByteArray) -> Boolean,
+        merge: suspend (ByteArray, ByteArray, Int) -> MergeResult,
+        filter: (ByteArray) -> Boolean,
+        trigger: suspend RemoteCharacteristic.() -> Unit,
     ): ByteArray = withCallSite("waitForValueChange") {
-        subscribe(trigger)
+        subscribe(mode, trigger)
             .filter(rawDataFilter)
             .mergeIndexed(merge)
             .firstOrNull(filter)
@@ -298,6 +301,11 @@ abstract class BaseRemoteCharacteristic(
 
     override fun subscribe(
         onSubscription: suspend RemoteCharacteristic.() -> Unit
+    ): Flow<ByteArray> = subscribe(SubscriptionMode.AUTOMATIC, onSubscription)
+
+    internal fun subscribe(
+        mode: SubscriptionMode,
+        onSubscription: suspend RemoteCharacteristic.() -> Unit,
     ): Flow<ByteArray> {
         // Check whether the characteristic wasn't invalidated.
         val owner = requireNotNull(owner) {
@@ -324,7 +332,7 @@ abstract class BaseRemoteCharacteristic(
                 val collectedHere = CallSiteException("subscribe() Flow started being collected here")
                 try {
                     // First, make sure the notifications or indications are enabled.
-                    setNotifying(true)
+                    setNotifying(true, mode)
                     // Then, invoke the user callback.
                     onSubscription()
                 } catch (e: CancellationException) {

--- a/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/SubscriptionController.kt
+++ b/client-core/src/main/java/no/nordicsemi/kotlin/ble/client/internal/SubscriptionController.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.client.internal
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import no.nordicsemi.kotlin.ble.client.SubscriptionMode
+import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
+import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
+import no.nordicsemi.kotlin.ble.core.OperationStatus
+import no.nordicsemi.kotlin.ble.core.exception.BluetoothException
+
+/** Coordinates local registration and the remote CCCD as one serialized transition. */
+internal class SubscriptionController {
+    private val mutex = Mutex()
+    private var activeMode: SubscriptionMode? = null
+
+    @Volatile
+    var isEnabled: Boolean = false
+        private set
+
+    suspend fun setNotifying(
+        enabled: Boolean,
+        requestedMode: SubscriptionMode,
+        properties: Set<CharacteristicProperty>,
+        setLocalRegistration: (Boolean) -> Unit,
+        writeCccd: suspend (ByteArray) -> Unit,
+    ) = mutex.withLock {
+        val resolvedMode = if (enabled) resolveSubscriptionMode(requestedMode, properties) else null
+
+        if (enabled == isEnabled && (!enabled || resolvedMode == activeMode)) return@withLock
+
+        val localRegistrationChanged = enabled != isEnabled
+        if (localRegistrationChanged) {
+            try {
+                setLocalRegistration(enabled)
+            } catch (e: OperationFailedException) {
+                throw e
+            } catch (e: Exception) {
+                throw BluetoothException(e)
+            }
+        }
+
+        var descriptorWritten = false
+        try {
+            writeCccd(cccdValue(enabled, resolvedMode))
+            descriptorWritten = true
+        } finally {
+            if (!descriptorWritten && localRegistrationChanged) {
+                try {
+                    setLocalRegistration(!enabled)
+                } catch (_: Exception) {
+                    // Preserve the descriptor write failure.
+                }
+            }
+        }
+
+        isEnabled = enabled
+        activeMode = resolvedMode
+    }
+}
+
+internal fun resolveSubscriptionMode(
+    requestedMode: SubscriptionMode,
+    properties: Set<CharacteristicProperty>,
+): SubscriptionMode = when (requestedMode) {
+    SubscriptionMode.AUTOMATIC -> when {
+        CharacteristicProperty.INDICATE in properties -> SubscriptionMode.INDICATION
+        CharacteristicProperty.NOTIFY in properties -> SubscriptionMode.NOTIFICATION
+        else -> unsupportedSubscriptionMode()
+    }
+
+    SubscriptionMode.NOTIFICATION ->
+        if (CharacteristicProperty.NOTIFY in properties) requestedMode else unsupportedSubscriptionMode()
+
+    SubscriptionMode.INDICATION ->
+        if (CharacteristicProperty.INDICATE in properties) requestedMode else unsupportedSubscriptionMode()
+}
+
+internal fun cccdValue(
+    enabled: Boolean,
+    resolvedMode: SubscriptionMode?,
+): ByteArray = when {
+    !enabled -> BaseRemoteDescriptor.DISABLE_NOTIFICATIONS_VALUE
+    resolvedMode == SubscriptionMode.NOTIFICATION -> BaseRemoteDescriptor.ENABLE_NOTIFICATIONS_VALUE
+    resolvedMode == SubscriptionMode.INDICATION -> BaseRemoteDescriptor.ENABLE_INDICATIONS_VALUE
+    else -> unsupportedSubscriptionMode()
+}
+
+private fun unsupportedSubscriptionMode(): Nothing =
+    throw OperationFailedException(OperationStatus.SubscribeNotPermitted)

--- a/client-core/src/test/java/no/nordicsemi/kotlin/ble/client/internal/SubscriptionModeTest.kt
+++ b/client-core/src/test/java/no/nordicsemi/kotlin/ble/client/internal/SubscriptionModeTest.kt
@@ -1,0 +1,586 @@
+/*
+ * Copyright (c) 2026, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.kotlin.ble.client.internal
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import no.nordicsemi.kotlin.ble.client.GattEvent
+import no.nordicsemi.kotlin.ble.client.Peripheral
+import no.nordicsemi.kotlin.ble.client.RemoteCharacteristic
+import no.nordicsemi.kotlin.ble.client.RemoteDescriptor
+import no.nordicsemi.kotlin.ble.client.RemoteIncludedService
+import no.nordicsemi.kotlin.ble.client.RemoteService
+import no.nordicsemi.kotlin.ble.client.SubscriptionMode
+import no.nordicsemi.kotlin.ble.client.exception.OperationFailedException
+import no.nordicsemi.kotlin.ble.client.setNotifying
+import no.nordicsemi.kotlin.ble.client.subscribe
+import no.nordicsemi.kotlin.ble.client.waitForValueChange
+import no.nordicsemi.kotlin.ble.core.CharacteristicProperty
+import no.nordicsemi.kotlin.ble.core.ConnectionState
+import no.nordicsemi.kotlin.ble.core.Environment
+import no.nordicsemi.kotlin.ble.core.OperationStatus
+import no.nordicsemi.kotlin.ble.core.WriteType
+import no.nordicsemi.kotlin.ble.core.util.MergeResult
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+class SubscriptionModeTest {
+    @Test
+    fun automaticModeRetainsIndicationPriorityWhenBothPropertiesExist() {
+        val mode = resolveSubscriptionMode(SubscriptionMode.AUTOMATIC, dualProperties)
+
+        assertEquals(SubscriptionMode.INDICATION, mode)
+        assertContentEquals(byteArrayOf(0x02, 0x00), cccdValue(enabled = true, mode))
+    }
+
+    @Test
+    fun notificationModeSelectsNotificationWhenBothPropertiesExist() {
+        val mode = resolveSubscriptionMode(SubscriptionMode.NOTIFICATION, dualProperties)
+
+        assertEquals(SubscriptionMode.NOTIFICATION, mode)
+        assertContentEquals(byteArrayOf(0x01, 0x00), cccdValue(enabled = true, mode))
+    }
+
+    @Test
+    fun indicationModeSelectsIndicationWhenBothPropertiesExist() {
+        val mode = resolveSubscriptionMode(SubscriptionMode.INDICATION, dualProperties)
+
+        assertEquals(SubscriptionMode.INDICATION, mode)
+        assertContentEquals(byteArrayOf(0x02, 0x00), cccdValue(enabled = true, mode))
+    }
+
+    @Test
+    fun automaticModeSelectsTheOnlyAdvertisedProperty() {
+        assertEquals(
+            SubscriptionMode.NOTIFICATION,
+            resolveSubscriptionMode(
+                SubscriptionMode.AUTOMATIC,
+                setOf(CharacteristicProperty.NOTIFY),
+            ),
+        )
+        assertEquals(
+            SubscriptionMode.INDICATION,
+            resolveSubscriptionMode(
+                SubscriptionMode.AUTOMATIC,
+                setOf(CharacteristicProperty.INDICATE),
+            ),
+        )
+    }
+
+    @Test
+    fun explicitNotificationRejectsACharacteristicWithoutNotify() {
+        val failure =
+            runCatching {
+                resolveSubscriptionMode(
+                    SubscriptionMode.NOTIFICATION,
+                    setOf(CharacteristicProperty.INDICATE),
+                )
+            }.exceptionOrNull()
+
+        assertEquals(OperationFailedException::class, failure?.let { it::class })
+        assertEquals(
+            OperationStatus.SubscribeNotPermitted,
+            (failure as OperationFailedException).reason,
+        )
+    }
+
+    @Test
+    fun explicitIndicationRejectsACharacteristicWithoutIndicate() {
+        val failure =
+            runCatching {
+                resolveSubscriptionMode(
+                    SubscriptionMode.INDICATION,
+                    setOf(CharacteristicProperty.NOTIFY),
+                )
+            }.exceptionOrNull()
+
+        assertEquals(OperationFailedException::class, failure?.let { it::class })
+        assertEquals(
+            OperationStatus.SubscribeNotPermitted,
+            (failure as OperationFailedException).reason,
+        )
+    }
+
+    @Test
+    fun disablingWritesTheDisabledCccdValue() {
+        assertContentEquals(
+            byteArrayOf(0x00, 0x00),
+            cccdValue(enabled = false, resolvedMode = null),
+        )
+    }
+
+    @Test
+    fun notificationTransitionRegistersLocallyAndWritesNotificationCccd() = runBlocking {
+        val controller = SubscriptionController()
+        val localRegistrations = mutableListOf<Boolean>()
+        val descriptorWrites = mutableListOf<ByteArray>()
+
+        controller.setNotifying(
+            enabled = true,
+            requestedMode = SubscriptionMode.NOTIFICATION,
+            properties = dualProperties,
+            setLocalRegistration = localRegistrations::add,
+            writeCccd = descriptorWrites::add,
+        )
+
+        assertTrue(controller.isEnabled)
+        assertEquals(listOf(true), localRegistrations)
+        assertByteArraysEqual(listOf(byteArrayOf(0x01, 0x00)), descriptorWrites)
+    }
+
+    @Test
+    fun baseSubscribeForwardsNotificationModeToTheCccdWrite() = runBlocking {
+        val fixture = BaseCharacteristicFixture()
+        val subscribed = CompletableDeferred<Unit>()
+        val collection = async {
+            fixture.characteristic
+                .subscribe(SubscriptionMode.NOTIFICATION) { subscribed.complete(Unit) }
+                .collect()
+        }
+
+        subscribed.await()
+
+        assertEquals(listOf(true), fixture.localRegistrations)
+        assertByteArraysEqual(listOf(byteArrayOf(0x01, 0x00)), fixture.descriptorWrites)
+        collection.cancelAndJoin()
+    }
+
+    @Test
+    fun baseWaitForValueChangeForwardsNotificationModeBeforeItsTrigger() = runBlocking {
+        val fixture = BaseCharacteristicFixture()
+        val expected = byteArrayOf(0x21, 0x43)
+
+        val actual =
+            fixture.characteristic.waitForValueChange(
+                mode = SubscriptionMode.NOTIFICATION,
+                rawDataFilter = { true },
+                merge = { _, received, _ -> MergeResult.Completed(received) },
+                filter = { true },
+                trigger = {
+                    assertByteArraysEqual(listOf(byteArrayOf(0x01, 0x00)), fixture.descriptorWrites)
+                    fixture.emitValue(expected)
+                },
+            )
+
+        assertContentEquals(expected, actual)
+        assertEquals(listOf(true), fixture.localRegistrations)
+        assertByteArraysEqual(listOf(byteArrayOf(0x01, 0x00)), fixture.descriptorWrites)
+    }
+
+    @Test
+    fun concurrentEquivalentRequestsProduceOneSerializedTransition() = runBlocking {
+        val controller = SubscriptionController()
+        val firstWriteEntered = CompletableDeferred<Unit>()
+        val releaseFirstWrite = CompletableDeferred<Unit>()
+        val localRegistrations = mutableListOf<Boolean>()
+        val descriptorWrites = mutableListOf<ByteArray>()
+
+        val first = async {
+            controller.setNotifying(
+                enabled = true,
+                requestedMode = SubscriptionMode.NOTIFICATION,
+                properties = dualProperties,
+                setLocalRegistration = localRegistrations::add,
+                writeCccd = { value ->
+                    descriptorWrites += value
+                    firstWriteEntered.complete(Unit)
+                    releaseFirstWrite.await()
+                },
+            )
+        }
+        firstWriteEntered.await()
+        val second = async {
+            controller.setNotifying(
+                enabled = true,
+                requestedMode = SubscriptionMode.NOTIFICATION,
+                properties = dualProperties,
+                setLocalRegistration = localRegistrations::add,
+                writeCccd = descriptorWrites::add,
+            )
+        }
+
+        yield()
+        assertEquals(1, descriptorWrites.size)
+        releaseFirstWrite.complete(Unit)
+        first.await()
+        second.await()
+
+        assertEquals(listOf(true), localRegistrations)
+        assertByteArraysEqual(listOf(byteArrayOf(0x01, 0x00)), descriptorWrites)
+    }
+
+    @Test
+    fun switchingModeRewritesCccdWithoutRepeatingLocalRegistration() = runBlocking {
+        val controller = SubscriptionController()
+        val localRegistrations = mutableListOf<Boolean>()
+        val descriptorWrites = mutableListOf<ByteArray>()
+
+        controller.setNotifying(
+            true,
+            SubscriptionMode.NOTIFICATION,
+            dualProperties,
+            localRegistrations::add,
+            descriptorWrites::add,
+        )
+        controller.setNotifying(
+            true,
+            SubscriptionMode.INDICATION,
+            dualProperties,
+            localRegistrations::add,
+            descriptorWrites::add,
+        )
+
+        assertTrue(controller.isEnabled)
+        assertEquals(listOf(true), localRegistrations)
+        assertByteArraysEqual(
+            listOf(byteArrayOf(0x01, 0x00), byteArrayOf(0x02, 0x00)),
+            descriptorWrites,
+        )
+    }
+
+    @Test
+    fun failedDescriptorWriteRollsBackLocalRegistrationAndState() = runBlocking {
+        val controller = SubscriptionController()
+        val localRegistrations = mutableListOf<Boolean>()
+
+        val failure = runCatching {
+            controller.setNotifying(
+                enabled = true,
+                requestedMode = SubscriptionMode.NOTIFICATION,
+                properties = dualProperties,
+                setLocalRegistration = localRegistrations::add,
+                writeCccd = { error("CCCD write failed") },
+            )
+        }.exceptionOrNull()
+
+        assertEquals(IllegalStateException::class, failure?.let { it::class })
+        assertEquals(listOf(true, false), localRegistrations)
+        assertFalse(controller.isEnabled)
+    }
+
+    @Test
+    fun cancelledDescriptorWriteRollsBackLocalRegistrationAndState() = runBlocking {
+        val controller = SubscriptionController()
+        val writeEntered = CompletableDeferred<Unit>()
+        val localRegistrations = mutableListOf<Boolean>()
+
+        val request = async {
+            controller.setNotifying(
+                enabled = true,
+                requestedMode = SubscriptionMode.NOTIFICATION,
+                properties = dualProperties,
+                setLocalRegistration = localRegistrations::add,
+                writeCccd = {
+                    writeEntered.complete(Unit)
+                    awaitCancellation()
+                },
+            )
+        }
+        writeEntered.await()
+        request.cancelAndJoin()
+
+        assertEquals(listOf(true, false), localRegistrations)
+        assertFalse(controller.isEnabled)
+    }
+
+    @Test
+    fun failedModeSwitchPreservesThePreviouslyCommittedMode() = runBlocking {
+        val controller = SubscriptionController()
+        val descriptorWrites = mutableListOf<ByteArray>()
+
+        controller.setNotifying(
+            true,
+            SubscriptionMode.NOTIFICATION,
+            dualProperties,
+            {},
+            descriptorWrites::add,
+        )
+        val failure = runCatching {
+            controller.setNotifying(
+                true,
+                SubscriptionMode.INDICATION,
+                dualProperties,
+                { error("Local registration must not change during a mode switch") },
+                { error("CCCD write failed") },
+            )
+        }.exceptionOrNull()
+        controller.setNotifying(
+            true,
+            SubscriptionMode.NOTIFICATION,
+            dualProperties,
+            { error("The committed notification registration must remain active") },
+            descriptorWrites::add,
+        )
+
+        assertTrue(controller.isEnabled)
+        assertEquals(IllegalStateException::class, failure?.let { it::class })
+        assertByteArraysEqual(listOf(byteArrayOf(0x01, 0x00)), descriptorWrites)
+    }
+
+    @Test
+    fun disablingPerformsOneOrderedTransitionAndIsIdempotent() = runBlocking {
+        val controller = SubscriptionController()
+        val operations = mutableListOf<String>()
+
+        controller.setNotifying(
+            true,
+            SubscriptionMode.NOTIFICATION,
+            dualProperties,
+            { operations += "local:$it" },
+            { operations += "cccd:${it.toHex()}" },
+        )
+        controller.setNotifying(
+            false,
+            SubscriptionMode.INDICATION,
+            dualProperties,
+            { operations += "local:$it" },
+            { operations += "cccd:${it.toHex()}" },
+        )
+        controller.setNotifying(
+            false,
+            SubscriptionMode.NOTIFICATION,
+            dualProperties,
+            { operations += "unexpected-local:$it" },
+            { operations += "unexpected-cccd:${it.toHex()}" },
+        )
+
+        assertFalse(controller.isEnabled)
+        assertEquals(
+            listOf("local:true", "cccd:0100", "local:false", "cccd:0000"),
+            operations,
+        )
+    }
+
+    @Test
+    fun explicitModeDoesNotPreventDisablingAnotherRemoteCharacteristicImplementation() = runBlocking {
+        val calls = mutableListOf<Boolean>()
+        val characteristic = remoteCharacteristicProxy { calls += it }
+
+        characteristic.setNotifying(false, SubscriptionMode.NOTIFICATION)
+
+        assertEquals(listOf(false), calls)
+    }
+
+    @Test
+    fun explicitModeRejectsEnablingAnotherRemoteCharacteristicImplementation() = runBlocking {
+        val calls = mutableListOf<Boolean>()
+        val characteristic = remoteCharacteristicProxy { calls += it }
+
+        val failure = runCatching {
+            characteristic.setNotifying(true, SubscriptionMode.NOTIFICATION)
+        }.exceptionOrNull()
+
+        assertEquals(OperationFailedException::class, failure?.let { it::class })
+        assertEquals(
+            OperationStatus.SubscribeNotPermitted,
+            (failure as OperationFailedException).reason,
+        )
+        assertTrue(calls.isEmpty())
+    }
+
+    private fun assertByteArraysEqual(
+        expected: List<ByteArray>,
+        actual: List<ByteArray>,
+    ) {
+        assertEquals(expected.size, actual.size)
+        expected.zip(actual).forEach { (expectedValue, actualValue) ->
+            assertContentEquals(expectedValue, actualValue)
+        }
+    }
+
+    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+
+    private fun remoteCharacteristicProxy(onSetNotifying: (Boolean) -> Unit): RemoteCharacteristic =
+        Proxy.newProxyInstance(
+            RemoteCharacteristic::class.java.classLoader,
+            arrayOf(RemoteCharacteristic::class.java),
+        ) { proxy, method, arguments ->
+            when (method.name) {
+                "setNotifying" -> {
+                    onSetNotifying(arguments?.first() as Boolean)
+                    Unit
+                }
+                "hashCode" -> System.identityHashCode(proxy)
+                "equals" -> proxy === arguments?.firstOrNull()
+                "toString" -> "RemoteCharacteristicProxy"
+                else -> error("Unexpected proxy call: ${method.name}")
+            }
+        } as RemoteCharacteristic
+
+    private class BaseCharacteristicFixture {
+        private val events = MutableSharedFlow<GattEvent>(extraBufferCapacity = 1)
+        private val executor = executor(events)
+        private val peripheral = TestPeripheral(executor)
+        private val service = TestService(peripheral)
+        val localRegistrations = mutableListOf<Boolean>()
+        val descriptorWrites = mutableListOf<ByteArray>()
+        private val implementation = TestCharacteristic(service, events, localRegistrations)
+        val characteristic: RemoteCharacteristic = implementation
+
+        init {
+            implementation.installDescriptor(TestDescriptor(implementation, events, descriptorWrites))
+        }
+
+        fun emitValue(value: ByteArray) {
+            check(events.tryEmit(CharacteristicChanged(implementation, value)))
+        }
+
+        private companion object {
+            @Suppress("UNCHECKED_CAST")
+            fun executor(events: MutableSharedFlow<GattEvent>): Peripheral.Executor<String> =
+                Proxy.newProxyInstance(
+                    Peripheral.Executor::class.java.classLoader,
+                    arrayOf(Peripheral.Executor::class.java),
+                ) { proxy, method, arguments ->
+                    when (method.name) {
+                        "getEnvironment" -> systemEnvironment
+                        "getIdentifier" -> "test-peripheral"
+                        "getInitialState" -> ConnectionState.Connected
+                        "getInitialServices" -> emptyList<RemoteService>()
+                        "getEvents" -> events
+                        "getName" -> "Test peripheral"
+                        "getLogger" -> null
+                        "getLogId" -> "test-peripheral"
+                        "isClosed", "isReliableWriteEnabled" -> false
+                        "setLogger", "setReliableWriteEnabled" -> Unit
+                        "hashCode" -> System.identityHashCode(proxy)
+                        "equals" -> proxy === arguments?.firstOrNull()
+                        "toString" -> "TestPeripheralExecutor"
+                        else -> error("Unexpected executor call: ${method.name}")
+                    }
+                } as Peripheral.Executor<String>
+
+            val systemEnvironment: Environment =
+                Proxy.newProxyInstance(
+                    Environment::class.java.classLoader,
+                    arrayOf(Environment::class.java),
+                ) { proxy, method, arguments ->
+                    when (method.name) {
+                        "isSystem", "isBluetoothSupported", "isBluetoothEnabled" -> true
+                        "getDeviceName" -> "Test environment"
+                        "hashCode" -> System.identityHashCode(proxy)
+                        "equals" -> proxy === arguments?.firstOrNull()
+                        "toString" -> "TestEnvironment"
+                        else -> false
+                    }
+                } as Environment
+        }
+    }
+
+    private class TestPeripheral(
+        executor: Peripheral.Executor<String>,
+    ) : Peripheral<String, Peripheral.Executor<String>>(
+            CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            executor,
+        ) {
+        override fun maximumWriteValueLength(type: WriteType): Int = 512
+    }
+
+    private class TestService(peripheral: TestPeripheral) : RemoteService() {
+        override val uuid = Uuid.parse("00001800-0000-1000-8000-00805f9b34fb")
+        override val instanceId: Int = 1
+        override val characteristics: List<RemoteCharacteristic> = emptyList()
+        override val includedServices: List<RemoteIncludedService> = emptyList()
+
+        init {
+            owner = peripheral
+        }
+    }
+
+    private class TestCharacteristic(
+        service: TestService,
+        events: MutableSharedFlow<GattEvent>,
+        private val localRegistrations: MutableList<Boolean>,
+    ) : BaseRemoteCharacteristic(service, events) {
+        override val uuid = Uuid.parse("00002a00-0000-1000-8000-00805f9b34fb")
+        override val instanceId: Int = 1
+        override val properties = dualProperties
+        override var descriptors: List<RemoteDescriptor> = emptyList()
+            private set
+
+        fun installDescriptor(descriptor: RemoteDescriptor) {
+            descriptors = listOf(descriptor)
+        }
+
+        override fun setCharacteristicNotification(enabled: Boolean) {
+            localRegistrations += enabled
+        }
+
+        override suspend fun FlowCollector<GattEvent>.executeRead() = error("Not used")
+
+        override suspend fun FlowCollector<GattEvent>.executeWrite(data: ByteArray, writeType: WriteType) =
+            error("Not used")
+
+        override fun OperationEvent.matches(): Boolean = subject === this@TestCharacteristic
+    }
+
+    private class TestDescriptor(
+        characteristic: TestCharacteristic,
+        events: MutableSharedFlow<GattEvent>,
+        private val writes: MutableList<ByteArray>,
+    ) : BaseRemoteDescriptor(characteristic, events) {
+        override val uuid = no.nordicsemi.kotlin.ble.core.Descriptor.CLIENT_CHAR_CONF_UUID
+        override val instanceId: Int = 1
+
+        override suspend fun FlowCollector<GattEvent>.executeRead() = error("Not used")
+
+        override suspend fun FlowCollector<GattEvent>.executeWrite(data: ByteArray) {
+            writes += data.copyOf()
+            emit(DescriptorWrite(this@TestDescriptor, OperationStatus.Success))
+        }
+
+        override fun OperationEvent.matches(): Boolean = subject === this@TestDescriptor
+    }
+
+    private companion object {
+        val dualProperties =
+            setOf(
+                CharacteristicProperty.NOTIFY,
+                CharacteristicProperty.INDICATE,
+            )
+    }
+}


### PR DESCRIPTION
## Summary

- add an explicit `SubscriptionMode` for automatic, notification, and indication selection
- preserve the existing indication-first automatic behavior for compatibility
- serialize CCCD transitions and restore local registration when setup fails or is cancelled
- allow mock peripherals to accept or reject notification and indication CCCD writes
- document the API and cover mode selection, concurrency, cancellation, rollback, and mock CCCD behavior

## Verification

- `./gradlew --rerun-tasks :client-core:test :client-core-mock:test :client-core-android:test :client-android:assemble :client-android-mock:build :client-core:dokkaGeneratePublicationHtml`
- 23 new focused tests pass
- affected client modules and Dokka generation pass

A complete `./gradlew build` was also attempted. It currently stops on existing `advertiser-android` `MissingPermission` lint findings unrelated to this change.

Fixes #349